### PR TITLE
Require bash (bad substitution)

### DIFF
--- a/docker-logs-localtime
+++ b/docker-logs-localtime
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # replace all UTC dates to local dates in pipe
 # by HuangYingNing <huangyingning at google mail system>
 # install:


### PR DESCRIPTION
I'm pretty sure the parameter expansion on line 14 requires Bash. On Ubuntu where the default shell is dash, the script fails with:
> docker-logs-localtime: 14: Bad substitution